### PR TITLE
Unpushed commits (local main ahead of origin/main)

### DIFF
--- a/.github/workflows/composer-audit.yml
+++ b/.github/workflows/composer-audit.yml
@@ -1,0 +1,37 @@
+name: Composer audit
+
+on:
+  push:
+    paths:
+      - 'composer.json'
+      - 'composer.lock'
+  pull_request:
+    paths:
+      - 'composer.json'
+      - 'composer.lock'
+  schedule:
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  composer-audit:
+    name: composer audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@2.37.0
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Resolve dependencies and audit
+        run: |
+          composer update --no-interaction --no-ansi
+          composer audit


### PR DESCRIPTION
Local main was 2 commit(s) ahead of origin/main. Opened from update-opensource-active.sh for review.